### PR TITLE
Delete MacOS dependencies that are no longer in the Core doc

### DIFF
--- a/articles/how-to-compile-bitcoin-core-and-run-the-tests.html
+++ b/articles/how-to-compile-bitcoin-core-and-run-the-tests.html
@@ -93,8 +93,8 @@ jon atack bitcoin core developer and protocol researcher
                       installed):
                       <code>
                         brew install automake berkeley-db4 libtool boost
-                        miniupnpc openssl pkg-config protobuf python qt libevent
-                        qrencode ccache
+                        miniupnpc pkg-config python qt libevent qrencode
+                        ccache
                       </code>
                     </li>
                   </ul>


### PR DESCRIPTION
https://github.com/bitcoin/bitcoin/blob/master/doc/build-osx.md#dependencies

Deleted openssl, protobuf, ~~ccache~~

