### PR TITLE
Remove ccache dependency for Linux / macOS

### DIFF
--- a/articles/how-to-compile-bitcoin-core-and-run-the-tests.html
+++ b/articles/how-to-compile-bitcoin-core-and-run-the-tests.html
@@ -94,7 +94,6 @@ jon atack bitcoin core developer and protocol researcher
                       <code>
                         brew install automake berkeley-db4 libtool boost
                         miniupnpc pkg-config python qt libevent qrencode
-                        ccache
                       </code>
                     </li>
                   </ul>


### PR DESCRIPTION
ccache does not appear to be a dependency required to compile anymore - https://github.com/bitcoin/bitcoin/blob/master/doc/dependencies.md