### PR TITLE
Update 'How to Compile Bitcoin Core'

### DIFF
--- a/articles/how-to-compile-bitcoin-core-and-run-the-tests.html
+++ b/articles/how-to-compile-bitcoin-core-and-run-the-tests.html
@@ -85,7 +85,7 @@ jon atack bitcoin core developer and protocol researcher
                         libboost-test-dev libboost-thread-dev libminiupnpc-dev
                         libzmq3-dev libqt5gui5 libqt5core5a libqt5dbus5
                         qttools5-dev qttools5-dev-tools libprotobuf-dev
-                        protobuf-compiler git sqlite3 ccache libsqlite3-dev
+                        protobuf-compiler git libsqlite3-dev ccache
                       </code>
                     </li>
                     <li>

--- a/articles/how-to-compile-bitcoin-core-and-run-the-tests.html
+++ b/articles/how-to-compile-bitcoin-core-and-run-the-tests.html
@@ -85,7 +85,7 @@ jon atack bitcoin core developer and protocol researcher
                         libboost-test-dev libboost-thread-dev libminiupnpc-dev
                         libzmq3-dev libqt5gui5 libqt5core5a libqt5dbus5
                         qttools5-dev qttools5-dev-tools libprotobuf-dev
-                        protobuf-compiler git sqlite3 ccache
+                        protobuf-compiler git sqlite3 ccache libsqlite3-dev
                       </code>
                     </li>
                     <li>


### PR DESCRIPTION
Add new dependency 'libsqlite3-dev'

This is for the linux install instructions only. I'm not sure if the `sqlite3` package is enough on Mac, and can't test on Mac hardware.